### PR TITLE
📝 Typos and Grammar

### DIFF
--- a/source/documentation/general-information/our-alliance.html.md.erb
+++ b/source/documentation/general-information/our-alliance.html.md.erb
@@ -1,10 +1,10 @@
 # Our alliance
 
-As a team, we regularly discuss and decide on our alliance, and document these openly and publicly.
+As a team, we regularly discuss and decide on our alliance. We document these openly and publicly.
 
-- We agree that it’s ok to disagree and challenge opinions
-- We agree that there are no stupid questions
-- We appreciate work takes time
-- We are respectful of others time
-- We code in the open
-- We have fun
+- We agree that it’s ok to disagree and challenge opinions.
+- We agree that there are no stupid questions.
+- We appreciate work takes time.
+- We are respectful of others time.
+- We code in the open.
+- We have fun.

--- a/source/documentation/general-information/our-ceremonies.html.md.erb
+++ b/source/documentation/general-information/our-ceremonies.html.md.erb
@@ -14,42 +14,47 @@ The CloudOps team has the following regular ceremonies.
 
 ## Stand Up 
 
-Our stand-ups run daily at 09:30 and last for 15 minutes.  We will follow one of two formats :
+Our stand-ups run daily at 09:30 and last for fifteen minutes.  We will follow one of two formats:
 
-- `Walk the board`: Starting with the "Done" column we discuss any active tickets in Jira.
-- `Yesterday, today, blockers`: A round robin of each team member discussing their tickets and any blockers.
+- **Walk The Board**
+
+    Starting with the "Done" column we discuss any active tickets in Jira.
+
+- **Yesterday, Today, Blockers**
+
+    A round robin of each team member discussing their tickets and any blockers.
 
 ## Sprint Planning 
 
-Our team runs on 2 week sprints that start on a Wednesday.  
-We use [Metro Retro](https://metroretro.io/) to run these sessions (usually 1hr). Template agenda below:
+Each Sprint is two weeks long and starts on a Wednesday. 
+We use [Metro Retro](https://metroretro.io/) to run a one-hour session. Template agenda below:
 
-1. Discuss the previous sprint and if we met our goal, did we achieve anything outside of our goal? (10m)
-1. Discuss tickets in the backlog and add sticky notes for a potential sprint goal and any risks concerns (10m)
-1. Reveal all stickies and vote for your favourite 5 votes (2m)
-1. Discuss the top 3 goals and finalise a sprint goal (15m)
-1. Discuss and finalise any concerns (5m)
-1. Pull tickets into the sprint
-1. Any other business
+1. Discuss the previous sprint and if we met our goal, did we achieve anything outside of our goal? (10m).
+1. Discuss tickets in the backlog and add sticky notes for a potential sprint goal and any risks concerns (10m).
+1. Reveal all stickies and vote for your favourite 5 votes (2m).
+1. Discuss the top 3 goals and finalise a sprint goal (15m).
+1. Discuss and finalise any concerns (5m).
+1. Pull tickets into the sprint.
+1. Any other business.
 
 ## Backlog Refinement
 
-On Monday mornings we have a 45m session on backlog refinement. This ceremony is for us to agree as a team that any ticket created has enough information for someone to pick up.  Once a ticket is refined we also estimate it using the [Fibonacci scale](https://en.wikipedia.org/wiki/Fibonacci_scale_(agile)).
+On Monday mornings we have a forty-five minute session on backlog refinement. The purpose of this ceremony is for the team to agree that any ticket created has enough information for any other team member to pick up.  Once a ticket is refined we also estimate it using the [Fibonacci scale](https://en.wikipedia.org/wiki/Fibonacci_scale_(agile)).
 
 ## Backlog Grooming
 
-A weekly 30m ceremony for ensuring the top of the backlog is prioritised.  It also stimulates discussion about potenital new tickets that should be created before refinement the following week.
+A weekly thirty-minute ceremony for ensuring the top of the backlog is prioritised.  It also stimulates discussion about potenital new tickets that should be created before refinement the following week.
 
 ## Show & Tell
 
-At the end of each sprint we have a 30 minute show and tell showcase to share with our colleagues and the wider organisation our achievements during the sprint. At the end of each sprint we have a 30 minute show and tell showcase to share with our colleagues and the wider organisation our achievements during the sprint. The showcase normally consists of an introduction summing up the sprint and if we met our sprint goal followed by demonstration and then what’s next in the road map.
+At the end of each sprint we have a thirty-minute show and tell showcase to share with our colleagues and the wider organisation our achievements during the sprint. At the end of each sprint we have a thirty-minute show and tell showcase to share with our colleagues and the wider organisation our achievements during the sprint. The showcase normally consists of an introduction summing up the sprint and if we met our sprint goal followed by demonstration and then what’s next in the road map.
 
 Example slide deck: [Sprint 40](https://docs.google.com/presentation/d/1QU68AOz0xpf-Z9hqGHEWBJXF75leE0rtKHithdKDSq4/edit?usp=sharing)
 
 ## Sprint Retrospective
 
-At the end of each sprint we have a 1hr retrospective.  This is for the team to openly discuss positives and negatives of the sprint.  The format is regularly changed to keep the retro fresh and effective.  For this we use [Parabol](https://parabol.co) 
+At the end of each sprint we have a one-hour retrospective.  This is for the team to openly discuss positives and negatives of the sprint.  The format, using [Parabol](https://parabol.co), is regularly changed to keep the retro fresh and effective. 
 
 ## Learn Tech
 
-We allocate Friday afternoons to learning. This time could be spent using one of the companies  resources such as Pluralsight, myLearning or any 3rd party course. Alternatively you may wish to spend the time looking into new technically or features that could benefit the team and our users. Lighting talks / demonstrations of any outcomes are greatly encouraged and welcomed.
+We allocate Friday afternoons to learning. This time could be spent using one of the companies  resources such as Pluralsight, myLearning or any 3rd party course. Alternatively you may wish to spend the time looking into new technically or features that could benefit the team and our users. Lightning Talks and Demonstrations of any outcomes are greatly encouraged and welcomed.

--- a/source/documentation/team-guide/team-tools.html.md.erb
+++ b/source/documentation/team-guide/team-tools.html.md.erb
@@ -2,7 +2,7 @@
 
 The intended readership of this page is new joiners to the team, the page illustrates tools which the team use frequently.
 
-### Windows Subsystem for Linux (WSL)
+### Windows Subsystem for Linux (WSL) 🐧
 
 Download the Ubuntu subsytem from the [Company Portal](companyportal:ApplicationId=59ecb0a7-0f6b-45fc-8242-1135bc2b538b).
 


### PR DESCRIPTION
- Changed e.g. "45 minute" to "forty-five minute" in general text. Left as 45m where appropriate. 
- Added full stops to the end of bullet points. 
- Made sentences more concise where possible.