### PR TITLE
:pencil2: fix adr link in README.md

### DIFF
--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -5,7 +5,7 @@ This is our architecture decision log, made during the design and build of Cloud
 ## Table of contents
 0. ✅ [Record architecture decisions](000-record-architecture-decisions.md)
 1. ✅ [Use BIND for Domain Naming System](001-use-bind-for-device-domain-naming-system.md)
-2. ❌ [Use Cloud Platform to host DHCP DNS](002-use-cloud-platform-to-host-dhcp-dns)
+2. ❌ [Use Cloud Platform to host DHCP DNS](002-use-cloud-platform-to-host-dhcp-dns.md)
 3. ✅  [Use AWS Elastic Container Service for DHCP DNS](003-use-aws-elastic-container-service-for-dhcp-dns.md)
 4. ✅ [Use AWS CodePipelines for CI/CD](004-use-aws-codepiplines-for-cicd.md)
 


### PR DESCRIPTION
small fix to correct link to 002-use-cloud-platform-to-host-dhcp-dns.md