### PR TITLE
:technologist: Update Story Template Test

### DIFF
--- a/.github/ISSUE_TEMPLATE/story-template.yml
+++ b/.github/ISSUE_TEMPLATE/story-template.yml
@@ -1,0 +1,65 @@
+name: Story Template
+description:  Create new Cloud Operations story
+title: "[gitmoji] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the fields below.
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      placeholder: "As a… *[who is the user?]*  
+                    I need/want/expect to… *[what does the user want to do?]*  
+                    So that… *[why does the user want to do this?]*"
+      value:  "As a… 
+              I need/want/expect to… 
+              So that…"
+    validations:
+      required: true
+  - type: textarea
+    id: value-purpose
+    attributes:
+      label: Value / Purpose
+      placeholder: Describe the value and purpose of the ticket.
+    validations:
+      required: false
+  - type: textarea
+    id: useful-contacts
+    attributes:
+      label: Useful Contacts
+      placeholder: Please add any useful contacts, these may include; Stakeholders, SME’s or 3rd Parties.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information 
+      value:  Please add any useful links or additional information that would be beneficial to anyone working on this ticket.
+    validations:
+      required: false
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      value: Please clearly and concisely detail the DoD.
+
+        Checklist for definition of done and acceptance criteria, example below (optional).
+
+        *Example*
+        - [ ] Documentation has been written / updated  
+        - [ ] README has been updated  
+        - [ ] User docs have been updated  
+        - [ ] Another team member has reviewed  
+        - [ ] Tests are green
+    validations:
+      required: false 
+  - type: textarea
+    id: reference
+    attributes:
+      label: Reference
+      value:  [How to write good user stories](https://www.gov.uk/service-manual/agile-delivery/writing-user-stories).
+    validations:
+      required: false


### PR DESCRIPTION
We noticed on the YACE repository that their issue used a [form ](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)and are seeking to test/replicate that for ourselves. 