### PR TITLE
📝Alter wording

### DIFF
--- a/source/documentation/general-information/our-ceremonies.html.md.erb
+++ b/source/documentation/general-information/our-ceremonies.html.md.erb
@@ -50,7 +50,7 @@ On Thursday afternoons we have a forty-five minute session on backlog refinement
 
 ## Backlog Grooming
 
-On Monday mornings we have a thirty-minute ceremony for ensuring the top of the backlog is prioritised.  It also stimulates discussion about potenital new issues that should be created before refinement the following week.
+On Monday mornings we have a thirty-minute ceremony for ensuring the top of the 'Ready for Development' queue is prioritised.  It also stimulates discussion about potenital new issues that should be created before refinement the following week.
 
 ## Show & Tell
 


### PR DESCRIPTION
Backlog Grooming referred to the Backlog which was true in the past but is no longer accurate whilst we use ZenHub, which has a Ready for Development queue. 