### PR TITLE
:triangular_flag_on_post: Set show govuk logo to false

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,8 +2,7 @@
 host: https://ministryofjustice.github.io/cloud-operations
 
 # Header-related options
-
-show_govuk_logo: true
+show_govuk_logo: false
 service_name: MoJ Cloud Operations
 
 service_link: /cloud-operations


### PR DESCRIPTION
Remove GOV.UK logo as per guidance [here](https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk)